### PR TITLE
ENH: Add `CLAUDE.md` + `python` rules for repo

### DIFF
--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "**/*.py"
+---
+
+# Python Style
+
+Prioritize idiomatic Python. Code should emphasize correctness, maintainability, and testability.
+
+## Types and Data Modeling
+
+- Favor strong types: proper classes, enums, and typed datastructures over raw strings or dicts
+- Use enums for fixed sets of values (configuration constants, mode selectors, etc.)
+- Use frozen dataclasses or Pydantic models for data — prefer immutable interfaces
+- Maintain clear module-level separation boundaries
+- Emphasize modular design patterns and composable interfaces
+
+## Control Flow and Structure
+
+- Favor `match` statements over `if`/`elif` chains when dispatching on values
+- Write code as data processing pipelines: pass inputs through composed functions rather than mutating shared state
+- Aim for a declarative/functional style where practical
+- Keep code flat — avoid deep nesting. Early returns over nested conditionals
+- Keep functions short and focused on a single responsibility
+- Apply DRY — extract shared logic rather than duplicating it
+- Favor stdlib modules for common patterns (`pathlib` for file I/O, `functools` for higher-order functions, `itertools` for iteration, `math` for math, etc.) rather than re-inventing logic
+
+## Naming
+
+- Use descriptive names for functions and variables — clarity over brevity
+- `snake_case` for functions and variables
+- `PascalCase` for classes
+- `ALL_CAPS` for module-level constants

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python -m ruff format src tests 2>/dev/null; uv run python -m ruff check --fix src tests 2>/dev/null; true"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Stellabook is an AI-powered service that retrieves arXiv research papers and generates interactive Jupyter notebooks for educational purposes. It uses multiple LLM providers for different tasks (paper analysis and notebook generation), orchestrated through LangChain.
+
+## Commands
+
+All commands use `uv` as the package manager and `just` as the task runner. See the `justfile` for available commands. Run `just` with no arguments to list them.
+
+## Architecture
+
+### Notebook Generation Pipeline
+
+```
+POST /generate (arxiv_id, interactive)
+  → arxiv_client: fetch paper metadata (Atom XML)
+  → figure_extractor: download PDF, extract/compress images
+  → generator: analyze paper and generate structured notebook content via LLMs
+  → notebook_builder.build_notebook(): assemble .ipynb with figures, imports
+  → return notebook file
+```
+
+### Module Responsibilities
+
+- **`config.py`** — Central configuration: LLM provider setup, arXiv constraints, figure limits
+- **`arxiv_client.py`** — Async arXiv API client with rate limiting and secure XML parsing
+- **`generator.py`** — LLM-driven steps in the notebook generation pipeline, each using a different provider. Contains the system prompts
+- **`figure_extractor.py`** — Downloads paper PDFs and extracts/compresses embedded images
+- **`notebook_builder.py`** — Assembles the final Jupyter notebook from generated content, figures, and metadata
+- **`models.py`** / **`notebook_models.py`** — Pydantic models for arXiv data and notebook structure
+- **`fastapi_app.py`** — FastAPI server exposing the notebook generation pipeline as a REST API
+
+### Key Design Decisions
+
+- **Multiple LLM providers**: Different models are used for different steps in the notebook generation pipeline. All accessed via LangChain abstractions in `config.py`.
+- **Structured output**: `generate_notebook_content()` uses LangChain's `.with_structured_output()` to return a typed `NotebookContent` Pydantic model.
+- **Figure handling**: Images under 40KB are inlined as base64 HTML; larger ones use notebook attachments. Images are progressively scaled down to meet size constraints.
+- **Import extraction**: `notebook_builder.extract_imports()` parses code cells with `ast` and maps module names to PyPI packages (e.g., `cv2` → `opencv-python`).
+
+## Testing
+
+Tests use `pytest` with `pytest-asyncio` (auto mode) and `pytest-httpx`. HTTP calls are mocked with `httpx.MockTransport`. LLM calls are mocked with `unittest.mock`. Sample Atom XML feeds are defined in `conftest.py`.
+
+## Environment Variables
+
+Requires `ANTHROPIC_API_KEY` and `GOOGLE_API_KEY` (see `.env.example`).
+
+## Code Standards
+
+- Python 3.12+ with strict Pyright type checking
+- Ruff for linting (rules: E, F, I, UP) and formatting
+- All public functions have type annotations
+- Async/await throughout the HTTP and notebook generation pipeline


### PR DESCRIPTION
## Summary
Adding some context files to the repo for slightly more consistent code output and patterns. 

- [x] `CLAUDE.md` for main context
- [x] `settings.json` for hooks/plugins
- [x] `python.md` rules for python specific coding context
