### PR TITLE
Refactor pipeline functions to use a context object

### DIFF
--- a/src/stellabook/fastapi_app.py
+++ b/src/stellabook/fastapi_app.py
@@ -13,6 +13,7 @@ from fastapi.responses import Response
 from stellabook.arxiv_client import ArxivClient
 from stellabook.config import get_notebook_model, get_research_model
 from stellabook.generator import generate_notebook_content, research_paper
+from stellabook.models import PipelineContext
 from stellabook.notebook_builder import build_notebook, notebook_to_json
 from stellabook.notebook_models import GenerateRequest
 from stellabook.observability import configure_observability
@@ -66,31 +67,31 @@ async def generate(request: GenerateRequest) -> Response:
                 exc_info=True,
             )
 
+    ctx = PipelineContext(
+        paper=paper,
+        research_model=app.state.research_model,
+        notebook_model=app.state.notebook_model,
+        paper_text=paper_text,
+        figures=figures,
+        interactive=request.interactive,
+    )
+
     with logfire.span("research paper", arxiv_id=paper.arxiv_id):
-        research = await research_paper(
-            paper, model=app.state.research_model, paper_text=paper_text
-        )
+        research = await research_paper(ctx)
 
     with logfire.span(
         "generate notebook content",
         arxiv_id=paper.arxiv_id,
         interactive=request.interactive,
     ):
-        content = await generate_notebook_content(
-            paper,
-            research,
-            figures=figures,
-            model=app.state.notebook_model,
-            interactive=request.interactive,
-            paper_text=paper_text,
-        )
+        content = await generate_notebook_content(ctx, research)
 
     with logfire.span(
         "build notebook",
         arxiv_id=paper.arxiv_id,
         cell_count=len(content.cells),
     ):
-        nb = build_notebook(content, paper=paper, figures=figures)
+        nb = build_notebook(content, paper=ctx.paper, figures=ctx.figures)
         nb_json = notebook_to_json(nb)
 
     filename = f"{request.arxiv_id.replace('/', '_')}.ipynb"

--- a/src/stellabook/fastapi_app.py
+++ b/src/stellabook/fastapi_app.py
@@ -91,7 +91,7 @@ async def generate(request: GenerateRequest) -> Response:
         arxiv_id=paper.arxiv_id,
         cell_count=len(content.cells),
     ):
-        nb = build_notebook(content, paper=ctx.paper, figures=ctx.figures)
+        nb = build_notebook(content, paper=paper, figures=figures)
         nb_json = notebook_to_json(nb)
 
     filename = f"{request.arxiv_id.replace('/', '_')}.ipynb"

--- a/src/stellabook/generator.py
+++ b/src/stellabook/generator.py
@@ -2,12 +2,10 @@
 
 from typing import cast
 
-from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from stellabook.config import get_notebook_model, get_research_model
-from stellabook.models import Paper
-from stellabook.notebook_models import Figure, NotebookContent
+from stellabook.models import PipelineContext
+from stellabook.notebook_models import NotebookContent
 
 RESEARCH_SYSTEM_PROMPT = """\
 You are a research scientist. Analyze the given arXiv paper in depth.
@@ -113,12 +111,9 @@ a multi-parameter visualization
 """
 
 
-def _build_user_message(
-    paper: Paper,
-    *,
-    paper_text: str | None = None,
-) -> str:
+def _build_user_message(ctx: PipelineContext) -> str:
     """Format paper metadata into a user message for the AI model."""
+    paper = ctx.paper
     authors = ", ".join(a.name for a in paper.authors)
     categories = ", ".join(c.term for c in paper.categories)
     msg = (
@@ -129,25 +124,19 @@ def _build_user_message(
         f"URL: {paper.abstract_url}\n\n"
         f"Abstract:\n{paper.summary}"
     )
-    if paper_text:
-        msg += f"\n\n---\n\nFull Paper Text:\n{paper_text}"
+    if ctx.paper_text:
+        msg += f"\n\n---\n\nFull Paper Text:\n{ctx.paper_text}"
     return msg
 
 
-def _build_notebook_user_message(
-    paper: Paper,
-    research: str,
-    figures: list[Figure] | None = None,
-    *,
-    paper_text: str | None = None,
-) -> str:
+def _build_notebook_user_message(ctx: PipelineContext, research: str) -> str:
     """Format paper metadata and research analysis into a message."""
-    paper_section = _build_user_message(paper, paper_text=paper_text)
+    paper_section = _build_user_message(ctx)
     msg = f"{paper_section}\n\n---\n\nResearch Analysis:\n{research}"
 
-    if figures:
+    if ctx.figures:
         msg += "\n\n---\n\nAvailable Figures:\n"
-        for fig in figures:
+        for fig in ctx.figures:
             msg += (
                 f"- {fig.label}: page {fig.page_number}, "
                 f"{fig.width}x{fig.height} pixels\n"
@@ -156,48 +145,32 @@ def _build_notebook_user_message(
     return msg
 
 
-async def research_paper(
-    paper: Paper,
-    *,
-    model: BaseChatModel | None = None,
-    paper_text: str | None = None,
-) -> str:
+async def research_paper(ctx: PipelineContext) -> str:
     """Analyze a paper in depth, returning markdown research."""
-    if model is None:
-        model = get_research_model()
-    response = await model.ainvoke(
+    response = await ctx.research_model.ainvoke(
         [
             SystemMessage(content=RESEARCH_SYSTEM_PROMPT),
-            HumanMessage(content=_build_user_message(paper, paper_text=paper_text)),
+            HumanMessage(content=_build_user_message(ctx)),
         ]
     )
     return cast(str, response.content)  # type: ignore[reportUnknownMemberType]
 
 
 async def generate_notebook_content(
-    paper: Paper,
+    ctx: PipelineContext,
     research: str,
-    *,
-    figures: list[Figure] | None = None,
-    model: BaseChatModel | None = None,
-    interactive: bool = False,
-    paper_text: str | None = None,
 ) -> NotebookContent:
     """Generate notebook content for a paper using structured output."""
-    if model is None:
-        model = get_notebook_model()
     system_prompt = NOTEBOOK_SYSTEM_PROMPT
-    if interactive:
+    if ctx.interactive:
         system_prompt += INTERACTIVE_NOTEBOOK_ADDENDUM
-    structured_model = model.with_structured_output(NotebookContent, include_raw=True)
+    structured_model = ctx.notebook_model.with_structured_output(
+        NotebookContent, include_raw=True
+    )
     result = await structured_model.ainvoke(
         [
             SystemMessage(content=system_prompt),
-            HumanMessage(
-                content=_build_notebook_user_message(
-                    paper, research, figures, paper_text=paper_text
-                )
-            ),
+            HumanMessage(content=_build_notebook_user_message(ctx, research)),
         ]
     )
     assert isinstance(result, dict)

--- a/src/stellabook/models.py
+++ b/src/stellabook/models.py
@@ -1,8 +1,17 @@
 """Pydantic models for arXiv paper data."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+    from stellabook.notebook_models import Figure
 
 
 class Author(BaseModel):
@@ -64,3 +73,15 @@ class SearchResult(BaseModel):
     start_index: int
     items_per_page: int
     papers: list[Paper]
+
+
+@dataclass(frozen=True)
+class PipelineContext:
+    """Carries pipeline-level state through the notebook generation chain."""
+
+    paper: Paper
+    research_model: BaseChatModel
+    notebook_model: BaseChatModel
+    paper_text: str | None = None
+    figures: list[Figure] | None = None
+    interactive: bool = False

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -8,7 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from stellabook.fastapi_app import app
 from stellabook.models import Author, Category, Paper, PipelineContext
-from stellabook.notebook_models import CellType, NotebookCell, NotebookContent
+from stellabook.notebook_models import CellType, Figure, NotebookCell, NotebookContent
 
 _MOCK_PAPER = Paper(
     arxiv_id="2301.07041",
@@ -45,7 +45,7 @@ class TestGenerateEndpoint:
         )
         mock_paper = _MOCK_PAPER
         mock_research = "## Background\nSome research."
-        mock_figures: list[object] = []
+        mock_figures: list[Figure] = []
         mock_pdf_bytes = b"fake-pdf"
         mock_paper_text = "Extracted paper text."
 
@@ -109,7 +109,7 @@ class TestGenerateEndpoint:
             research_model=mock_research_model,
             notebook_model=mock_notebook_model,
             paper_text=mock_paper_text,
-            figures=mock_figures,  # type: ignore[arg-type]
+            figures=mock_figures,
             interactive=False,
         )
         mock_research_fn.assert_called_once_with(expected_ctx)
@@ -124,7 +124,7 @@ class TestGenerateEndpoint:
         )
         mock_paper = _MOCK_PAPER
         mock_research = "## Background\nSome research."
-        mock_figures: list[object] = []
+        mock_figures: list[Figure] = []
         mock_pdf_bytes = b"fake-pdf"
         mock_paper_text = "Extracted paper text."
 
@@ -174,7 +174,7 @@ class TestGenerateEndpoint:
             research_model=mock_research_model,
             notebook_model=mock_notebook_model,
             paper_text=mock_paper_text,
-            figures=mock_figures,  # type: ignore[arg-type]
+            figures=mock_figures,
             interactive=True,
         )
         mock_gen.assert_called_once_with(expected_ctx, mock_research)
@@ -205,7 +205,7 @@ class TestGenerateEndpoint:
         )
         mock_paper = _MOCK_PAPER
         mock_research = "## Background\nSome research."
-        mock_figures: list[object] = []
+        mock_figures: list[Figure] = []
         mock_pdf_bytes = b"fake-pdf"
 
         mock_research_model = MagicMock()
@@ -254,7 +254,7 @@ class TestGenerateEndpoint:
             research_model=mock_research_model,
             notebook_model=mock_notebook_model,
             paper_text=None,
-            figures=mock_figures,  # type: ignore[arg-type]
+            figures=mock_figures,
             interactive=False,
         )
         mock_research_fn.assert_called_once_with(expected_ctx)
@@ -269,7 +269,7 @@ class TestGenerateEndpoint:
         )
         mock_paper = _MOCK_PAPER
         mock_research = "## Background\nSome research."
-        mock_figures: list[object] = []
+        mock_figures: list[Figure] = []
 
         mock_research_model = MagicMock()
         mock_notebook_model = MagicMock()
@@ -317,7 +317,7 @@ class TestGenerateEndpoint:
             research_model=mock_research_model,
             notebook_model=mock_notebook_model,
             paper_text=None,
-            figures=mock_figures,  # type: ignore[arg-type]
+            figures=mock_figures,
             interactive=False,
         )
         mock_research_fn.assert_called_once_with(expected_ctx)

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import ASGITransport, AsyncClient
 
 from stellabook.fastapi_app import app
-from stellabook.models import Author, Category, Paper
+from stellabook.models import Author, Category, Paper, PipelineContext
 from stellabook.notebook_models import CellType, NotebookCell, NotebookContent
 
 _MOCK_PAPER = Paper(
@@ -103,17 +103,17 @@ class TestGenerateEndpoint:
         mock_download.assert_called_once_with(mock_paper)
         mock_extract.assert_called_once_with(mock_paper, pdf_bytes=mock_pdf_bytes)
         mock_extract_text.assert_called_once_with(mock_pdf_bytes)
-        mock_research_fn.assert_called_once_with(
-            mock_paper, model=mock_research_model, paper_text=mock_paper_text
-        )
-        mock_gen.assert_called_once_with(
-            mock_paper,
-            mock_research,
-            figures=mock_figures,
-            model=mock_notebook_model,
-            interactive=False,
+
+        expected_ctx = PipelineContext(
+            paper=mock_paper,
+            research_model=mock_research_model,
+            notebook_model=mock_notebook_model,
             paper_text=mock_paper_text,
+            figures=mock_figures,  # type: ignore[arg-type]
+            interactive=False,
         )
+        mock_research_fn.assert_called_once_with(expected_ctx)
+        mock_gen.assert_called_once_with(expected_ctx, mock_research)
 
     async def test_generate_passes_interactive_flag(self) -> None:
         mock_content = NotebookContent(
@@ -169,14 +169,15 @@ class TestGenerateEndpoint:
                 )
 
         assert response.status_code == 200
-        mock_gen.assert_called_once_with(
-            mock_paper,
-            mock_research,
-            figures=mock_figures,
-            model=mock_notebook_model,
-            interactive=True,
+        expected_ctx = PipelineContext(
+            paper=mock_paper,
+            research_model=mock_research_model,
+            notebook_model=mock_notebook_model,
             paper_text=mock_paper_text,
+            figures=mock_figures,  # type: ignore[arg-type]
+            interactive=True,
         )
+        mock_gen.assert_called_once_with(expected_ctx, mock_research)
 
     async def test_generate_returns_404_for_unknown_paper(self) -> None:
         with patch("stellabook.fastapi_app.ArxivClient") as mock_arxiv_cls:
@@ -248,17 +249,16 @@ class TestGenerateEndpoint:
                 )
 
         assert response.status_code == 200
-        mock_research_fn.assert_called_once_with(
-            mock_paper, model=mock_research_model, paper_text=None
-        )
-        mock_gen.assert_called_once_with(
-            mock_paper,
-            mock_research,
-            figures=mock_figures,
-            model=mock_notebook_model,
-            interactive=False,
+        expected_ctx = PipelineContext(
+            paper=mock_paper,
+            research_model=mock_research_model,
+            notebook_model=mock_notebook_model,
             paper_text=None,
+            figures=mock_figures,  # type: ignore[arg-type]
+            interactive=False,
         )
+        mock_research_fn.assert_called_once_with(expected_ctx)
+        mock_gen.assert_called_once_with(expected_ctx, mock_research)
 
     async def test_generate_skips_text_extraction_when_no_pdf(self) -> None:
         mock_content = NotebookContent(
@@ -312,14 +312,13 @@ class TestGenerateEndpoint:
 
         assert response.status_code == 200
         mock_extract_text.assert_not_called()
-        mock_research_fn.assert_called_once_with(
-            mock_paper, model=mock_research_model, paper_text=None
-        )
-        mock_gen.assert_called_once_with(
-            mock_paper,
-            mock_research,
-            figures=mock_figures,
-            model=mock_notebook_model,
-            interactive=False,
+        expected_ctx = PipelineContext(
+            paper=mock_paper,
+            research_model=mock_research_model,
+            notebook_model=mock_notebook_model,
             paper_text=None,
+            figures=mock_figures,  # type: ignore[arg-type]
+            interactive=False,
         )
+        mock_research_fn.assert_called_once_with(expected_ctx)
+        mock_gen.assert_called_once_with(expected_ctx, mock_research)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -14,7 +14,7 @@ from stellabook.generator import (
     generate_notebook_content,
     research_paper,
 )
-from stellabook.models import Author, Category, Paper
+from stellabook.models import Author, Category, Paper, PipelineContext
 from stellabook.notebook_models import CellType, Figure, NotebookContent
 
 
@@ -29,6 +29,25 @@ def _make_paper() -> Paper:
         published=datetime(2023, 1, 17, tzinfo=UTC),
         updated=datetime(2023, 1, 17, tzinfo=UTC),
         primary_category="cs.AI",
+    )
+
+
+def _make_ctx(
+    paper: Paper | None = None,
+    *,
+    research_model: object | None = None,
+    notebook_model: object | None = None,
+    paper_text: str | None = None,
+    figures: list[Figure] | None = None,
+    interactive: bool = False,
+) -> PipelineContext:
+    return PipelineContext(
+        paper=paper or _make_paper(),
+        research_model=research_model or MagicMock(),  # type: ignore[arg-type]
+        notebook_model=notebook_model or MagicMock(),  # type: ignore[arg-type]
+        paper_text=paper_text,
+        figures=figures,
+        interactive=interactive,
     )
 
 
@@ -60,8 +79,8 @@ Apply to domain D.
 
 class TestBuildUserMessage:
     def test_contains_paper_fields(self) -> None:
-        paper = _make_paper()
-        msg = _build_user_message(paper)
+        ctx = _make_ctx()
+        msg = _build_user_message(ctx)
 
         assert "Test Paper Title" in msg
         assert "Alice" in msg
@@ -72,23 +91,23 @@ class TestBuildUserMessage:
         assert "https://arxiv.org/abs/2301.07041" in msg
 
     def test_includes_paper_text_when_provided(self) -> None:
-        paper = _make_paper()
-        msg = _build_user_message(paper, paper_text="Full text here.")
+        ctx = _make_ctx(paper_text="Full text here.")
+        msg = _build_user_message(ctx)
 
         assert "Full Paper Text:" in msg
         assert "Full text here." in msg
 
     def test_omits_paper_text_when_none(self) -> None:
-        paper = _make_paper()
-        msg = _build_user_message(paper, paper_text=None)
+        ctx = _make_ctx(paper_text=None)
+        msg = _build_user_message(ctx)
 
         assert "Full Paper Text:" not in msg
 
 
 class TestBuildNotebookUserMessage:
     def test_contains_research_fields(self) -> None:
-        paper = _make_paper()
-        msg = _build_notebook_user_message(paper, SAMPLE_RESEARCH)
+        ctx = _make_ctx()
+        msg = _build_notebook_user_message(ctx, SAMPLE_RESEARCH)
 
         assert "Test Paper Title" in msg
         assert "Research Analysis:" in msg
@@ -99,7 +118,6 @@ class TestBuildNotebookUserMessage:
         assert "Demo attention mechanism" in msg
 
     def test_includes_figures_section_when_provided(self) -> None:
-        paper = _make_paper()
         figures = [
             Figure(
                 label="figure_0",
@@ -116,29 +134,28 @@ class TestBuildNotebookUserMessage:
                 height=300,
             ),
         ]
-        msg = _build_notebook_user_message(paper, SAMPLE_RESEARCH, figures)
+        ctx = _make_ctx(figures=figures)
+        msg = _build_notebook_user_message(ctx, SAMPLE_RESEARCH)
 
         assert "Available Figures:" in msg
         assert "figure_0: page 1, 200x150 pixels" in msg
         assert "figure_1: page 3, 400x300 pixels" in msg
 
     def test_no_figures_section_when_empty(self) -> None:
-        paper = _make_paper()
-        msg = _build_notebook_user_message(paper, SAMPLE_RESEARCH, [])
+        ctx = _make_ctx(figures=[])
+        msg = _build_notebook_user_message(ctx, SAMPLE_RESEARCH)
 
         assert "Available Figures:" not in msg
 
     def test_no_figures_section_when_none(self) -> None:
-        paper = _make_paper()
-        msg = _build_notebook_user_message(paper, SAMPLE_RESEARCH, None)
+        ctx = _make_ctx(figures=None)
+        msg = _build_notebook_user_message(ctx, SAMPLE_RESEARCH)
 
         assert "Available Figures:" not in msg
 
     def test_forwards_paper_text(self) -> None:
-        paper = _make_paper()
-        msg = _build_notebook_user_message(
-            paper, SAMPLE_RESEARCH, paper_text="Full text here."
-        )
+        ctx = _make_ctx(paper_text="Full text here.")
+        msg = _build_notebook_user_message(ctx, SAMPLE_RESEARCH)
 
         assert "Full Paper Text:" in msg
         assert "Full text here." in msg
@@ -146,12 +163,11 @@ class TestBuildNotebookUserMessage:
 
 class TestResearchPaper:
     async def test_calls_model_and_returns_markdown(self) -> None:
-        paper = _make_paper()
-
         mock_model = AsyncMock()
         mock_model.ainvoke.return_value = AIMessage(content=SAMPLE_RESEARCH)
+        ctx = _make_ctx(research_model=mock_model)
 
-        result = await research_paper(paper, model=mock_model)
+        result = await research_paper(ctx)
 
         assert isinstance(result, str)
         assert "Addresses gap in X." in result
@@ -162,12 +178,11 @@ class TestResearchPaper:
         assert "Test Paper Title" in messages[1].content
 
     async def test_passes_paper_text_to_message(self) -> None:
-        paper = _make_paper()
-
         mock_model = AsyncMock()
         mock_model.ainvoke.return_value = AIMessage(content=SAMPLE_RESEARCH)
+        ctx = _make_ctx(research_model=mock_model, paper_text="Full text.")
 
-        await research_paper(paper, model=mock_model, paper_text="Full text.")
+        await research_paper(ctx)
 
         messages = mock_model.ainvoke.call_args.args[0]
         assert "Full Paper Text:" in messages[1].content
@@ -176,7 +191,6 @@ class TestResearchPaper:
 
 class TestGenerateNotebookContent:
     async def test_calls_model_with_structured_output(self) -> None:
-        paper = _make_paper()
         parsed = NotebookContent(
             title="Generated Notebook",
             cells=[
@@ -198,9 +212,8 @@ class TestGenerateNotebookContent:
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
-        result = await generate_notebook_content(
-            paper, SAMPLE_RESEARCH, model=mock_model
-        )
+        ctx = _make_ctx(notebook_model=mock_model)
+        result = await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
         assert result.title == "Generated Notebook"
         assert len(result.cells) == 2
@@ -217,7 +230,6 @@ class TestGenerateNotebookContent:
         assert "Addresses gap in X." in messages[1].content
 
     async def test_raises_on_max_tokens(self) -> None:
-        paper = _make_paper()
         parsed = NotebookContent(
             title="Partial",
             cells=[{"cell_type": "markdown", "source": "# Partial"}],  # type: ignore[list-item]
@@ -236,14 +248,13 @@ class TestGenerateNotebookContent:
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
+        ctx = _make_ctx(notebook_model=mock_model)
         with pytest.raises(ValueError, match="truncated"):
-            await generate_notebook_content(paper, SAMPLE_RESEARCH, model=mock_model)
+            await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
     async def test_raises_max_tokens_over_parsing_error(self) -> None:
         """When max_tokens causes truncation that also triggers a parsing error,
         the max_tokens error takes priority for a clearer message."""
-        paper = _make_paper()
-
         raw_message = AIMessage(content="")
         raw_message.response_metadata = {"stop_reason": "max_tokens"}
 
@@ -251,18 +262,19 @@ class TestGenerateNotebookContent:
         structured_model.ainvoke.return_value = {
             "raw": raw_message,
             "parsed": None,
-            "parsing_error": "1 validation error for NotebookContent\ncells\n  Field required",
+            "parsing_error": (
+                "1 validation error for NotebookContent\ncells\n  Field required"
+            ),
         }
 
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
+        ctx = _make_ctx(notebook_model=mock_model)
         with pytest.raises(ValueError, match="truncated"):
-            await generate_notebook_content(paper, SAMPLE_RESEARCH, model=mock_model)
+            await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
     async def test_raises_on_parsing_error(self) -> None:
-        paper = _make_paper()
-
         raw_message = AIMessage(content="")
         raw_message.response_metadata = {"stop_reason": "end_turn"}
 
@@ -276,11 +288,11 @@ class TestGenerateNotebookContent:
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
+        ctx = _make_ctx(notebook_model=mock_model)
         with pytest.raises(ValueError, match="Failed to parse notebook content"):
-            await generate_notebook_content(paper, SAMPLE_RESEARCH, model=mock_model)
+            await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
     async def test_uses_base_prompt_when_not_interactive(self) -> None:
-        paper = _make_paper()
         parsed = NotebookContent(
             title="Generated Notebook",
             cells=[
@@ -301,9 +313,8 @@ class TestGenerateNotebookContent:
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
-        await generate_notebook_content(
-            paper, SAMPLE_RESEARCH, model=mock_model, interactive=False
-        )
+        ctx = _make_ctx(notebook_model=mock_model, interactive=False)
+        await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
         messages = structured_model.ainvoke.call_args.args[0]
         system_content = messages[0].content
@@ -312,7 +323,6 @@ class TestGenerateNotebookContent:
         assert "@interact" not in system_content
 
     async def test_appends_interactive_addendum(self) -> None:
-        paper = _make_paper()
         parsed = NotebookContent(
             title="Generated Notebook",
             cells=[
@@ -333,9 +343,8 @@ class TestGenerateNotebookContent:
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
-        await generate_notebook_content(
-            paper, SAMPLE_RESEARCH, model=mock_model, interactive=True
-        )
+        ctx = _make_ctx(notebook_model=mock_model, interactive=True)
+        await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
         messages = structured_model.ainvoke.call_args.args[0]
         system_content = messages[0].content
@@ -347,7 +356,6 @@ class TestGenerateNotebookContent:
 
     async def test_handles_latex_in_structured_output(self) -> None:
         """Structured output handles LaTeX escaping correctly."""
-        paper = _make_paper()
         parsed = NotebookContent(
             title="Math Notebook",
             cells=[
@@ -371,15 +379,13 @@ class TestGenerateNotebookContent:
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
-        result = await generate_notebook_content(
-            paper, SAMPLE_RESEARCH, model=mock_model
-        )
+        ctx = _make_ctx(notebook_model=mock_model)
+        result = await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
         assert "\\alpha" in result.cells[0].source
         assert "\\beta" in result.cells[0].source
 
     async def test_passes_paper_text_to_message(self) -> None:
-        paper = _make_paper()
         parsed = NotebookContent(
             title="Generated Notebook",
             cells=[
@@ -400,9 +406,8 @@ class TestGenerateNotebookContent:
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value = structured_model
 
-        await generate_notebook_content(
-            paper, SAMPLE_RESEARCH, model=mock_model, paper_text="Full text."
-        )
+        ctx = _make_ctx(notebook_model=mock_model, paper_text="Full text.")
+        await generate_notebook_content(ctx, SAMPLE_RESEARCH)
 
         messages = structured_model.ainvoke.call_args.args[0]
         assert "Full Paper Text:" in messages[1].content


### PR DESCRIPTION
## Summary
- Introduces a frozen `PipelineContext` dataclass in `models.py` that bundles pipeline-level state: `paper`, `research_model`, `notebook_model`, `paper_text`, `figures`, and `interactive`
- Refactors `generator.py` functions (`research_paper`, `generate_notebook_content`, `_build_user_message`, `_build_notebook_user_message`) to accept a single context object instead of threading individual keyword arguments
- Updates `fastapi_app.py` to construct and pass `PipelineContext` through the pipeline

## Test plan
- [x] All existing tests pass with updated signatures (116 passed)
- [x] Ruff lint passes on changed files
- [x] Pyright type checking passes (only pre-existing errors on unrelated files)
- [x] Verify pipeline behavior is unchanged (mock assertions validate correct arguments)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)